### PR TITLE
GR: updating 'for' to 'if' in comments

### DIFF
--- a/gcta-python/notebooks/practice/new/ConditionalStatementPracticeReading.ipynb
+++ b/gcta-python/notebooks/practice/new/ConditionalStatementPracticeReading.ipynb
@@ -32,10 +32,10 @@
     "{keyword > if <} {expression_that_evaluates_to_a_boolean}{semicolon}\n",
     "    {indented code}\n",
     "\n",
-    "for some_bool:\n",
+    "if some_bool:\n",
     "    # your code\n",
     "\n",
-    "for (2 > 0):\n",
+    "if (2 > 0):\n",
     "    print('foo')\n",
     "\n",
     "''';\n",
@@ -812,6 +812,14 @@
     "usr_answer_diff = input('Assignment difficulty \\n(0 Too Easy) (1 Easy) (2 Intermediate) (3 Hard) (4 Too Hard): ')\n",
     "display(HTML(f'{scroll_fix}</style><span {style}><br>{usr_answer_time}<br><br>{usr_answer_diff}</span>'))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8526db87-fa31-49d0-93e9-a0fb7b6c5f5e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -830,7 +838,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.10.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Reviewing new practice notebooks and only saw one typo:

`if` instead of `for`